### PR TITLE
removed deprecation warnings and access logs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,27 @@ WORKDIR /app
 ADD ["start.sh", "circus.ini", "airflow_scheduler.sh", "airflow_web.sh", "dag-fetcher.sh", "./"]
 
 RUN apk add --update --no-cache gcc g++ libstdc++ coreutils linux-headers bash \
- && pip install --upgrade --ignore-installed setuptools "apache-airflow[s3,postgres]==1.8.2rc1" circus awscli boto boto3 \
+ && pip install --upgrade --ignore-installed setuptools "apache-airflow[s3,postgres]==1.8.2rc1" circus awscli boto boto3 flask-caching \
  && apk del gcc g++ linux-headers \
  && rm -rf /var/cache/apk/* \
  && rm -rf /root/.cache \
  && mkdir -p /app/airflow/dags \
  && chmod a+x *.sh  \
  && sed -i 's/BASE_LOG_URL =.*$/BASE_LOG_URL = "\/app\/airflow\/logs"/g' /opt/conda/lib/python3.6/site-packages/airflow/settings.py \
- && sed -i '/print(settings.HEADER)/d' /opt/conda/lib/python3.6/site-packages/airflow/bin/cli.py
+ # Fixing deprecation warnings the hard way (don't do this at home)
+ #
+ && sed -i '/print(settings.HEADER)/d' /opt/conda/lib/python3.6/site-packages/airflow/bin/cli.py \
+ && sed -i "s/CsrfProtect/CSRFProtect/g" /opt/conda/lib/python3.6/site-packages/airflow/www/app.py \
+ # Flask-caching is compatible with Flask-cache so this should fix the warning
+ # without breaking the airflow.
+ #
+ && sed -i 's/from flask_cache/from flask_caching/g' /opt/conda/lib/python3.6/site-packages/airflow/www/app.py\
+ # Fixing flask_wtf.Form and cgi.escape warnings might not be needed but they
+ # appear in the logs if you use the webapp.
+ #
+ && sed -i 's/from flask_wtf import Form/from flask_wtf import FlaskForm/g' /opt/conda/lib/python3.6/site-packages/airflow/www/forms.py \
+ && sed -i 's/(Form):/(FlaskForm):/g' /opt/conda/lib/python3.6/site-packages/airflow/www/forms.py \
+ && sed -i 's/from cgi import escape/from html import escape/g' /opt/conda/lib/python3.6/site-packages/airflow/www/utils.py
 
 EXPOSE 8080
 

--- a/airflow_web.sh
+++ b/airflow_web.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-airflow webserver 
+airflow webserver -A /dev/null


### PR DESCRIPTION
This PR:

- Remove access logs by setting `/dev/null` as the log file for the access log stream (errors still go to stderr)
- Removes the warning about `CsrfProtect` by renaming it to `CSRFProtect`
- Removes the warning about the deprecated `flask-cache` package by installing `flask-caching` and using it instead (`flask-caching` should be a direct replacement of `flask-cache`)
- Removes the warning about `Form` by renaming it to `FlaskForm`
- Remove the warning about `cgi.escape` by importing it from `html`.

All but the `CsrfProtect` warning and the warnings about `flask_cache` are not triggered by the scheduling of jobs, but are still present in the logs when using the web UI.